### PR TITLE
Add owner field to Geyser entity

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -35,6 +35,8 @@ type Geyser @entity {
   # geyser contract address
   id: ID!
 
+  owner: User!
+
   # geyser config
   stakingToken: Token!
   rewardToken: Token!
@@ -95,6 +97,9 @@ type User @entity {
 
   # global positions
   positions: [Position!] @derivedFrom(field: "user")
+
+  # geysers owned by this user
+  geysers: [Geyser!] @derivedFrom(field: "owner")
 }
 
 type Position @entity {

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -6,7 +6,7 @@ import { Geyser as GeyserContract } from '../../generated/GeyserFactory/Geyser'
 import { ERC20 } from '../../generated/GeyserFactory/ERC20'
 import { Geyser, Token, User } from '../../generated/schema'
 import { Geyser as GeyserTemplate } from '../../generated/templates'
-import { integerToDecimal, initializeUser } from '../util/common'
+import { integerToDecimal, createNewUser } from '../util/common'
 import { ZERO_BIG_INT, ZERO_BIG_DECIMAL } from '../util/constants'
 import { createNewToken } from '../pricing/token'
 
@@ -35,7 +35,7 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   let user = User.load(event.params.user.toHexString());
 
   if (user == null) {
-    user = initializeUser(event.params.user);
+    user = createNewUser(event.params.user);
   }
 
   // geyser entity

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -4,9 +4,9 @@ import { Address, BigInt, BigDecimal, log } from '@graphprotocol/graph-ts'
 import { GeyserFactory, GeyserCreated } from '../../generated/GeyserFactory/GeyserFactory'
 import { Geyser as GeyserContract } from '../../generated/GeyserFactory/Geyser'
 import { ERC20 } from '../../generated/GeyserFactory/ERC20'
-import { Geyser, Token } from '../../generated/schema'
+import { Geyser, Token, User } from '../../generated/schema'
 import { Geyser as GeyserTemplate } from '../../generated/templates'
-import { integerToDecimal } from '../util/common'
+import { integerToDecimal, initializeUser } from '../util/common'
 import { ZERO_BIG_INT, ZERO_BIG_DECIMAL } from '../util/constants'
 import { createNewToken } from '../pricing/token'
 
@@ -32,8 +32,15 @@ export function handleGeyserCreated(event: GeyserCreated): void {
     rewardToken.save();
   }
 
+  let user = User.load(event.params.user.toHexString());
+
+  if (user == null) {
+    user = initializeUser(event.params.user);
+  }
+
   // geyser entity
   let geyser = new Geyser(event.params.geyser.toHexString());
+  geyser.owner = user.id;
   geyser.stakingToken = stakingToken.id;
   geyser.rewardToken = rewardToken.id;
   geyser.bonusMin = integerToDecimal(contract.bonusMin());
@@ -67,6 +74,7 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   geyser.updated = ZERO_BIG_INT;
 
   geyser.save();
+  user.save();
 
   // create template event handler
   GeyserTemplate.create(event.params.geyser);

--- a/src/mappings/geyser.ts
+++ b/src/mappings/geyser.ts
@@ -241,6 +241,7 @@ export function handleOwnershipTransferred(event: OwnershipTransferred): void {
   let newOwner = User.load(event.params.newOwner.toHexString());
   if (newOwner == null) {
     newOwner = createNewUser(event.params.newOwner);
+    newOwner.save()
   }
 
   geyser.owner = newOwner.id;

--- a/src/mappings/geyser.ts
+++ b/src/mappings/geyser.ts
@@ -12,7 +12,7 @@ import {
   GysrSpent
 } from '../../generated/templates/Geyser/Geyser'
 import { Geyser, Token, User, Position, Stake, Platform } from '../../generated/schema'
-import { integerToDecimal } from '../util/common'
+import { integerToDecimal, initializeUser } from '../util/common'
 import { ZERO_BIG_INT, ZERO_BIG_DECIMAL, ZERO_ADDRESS } from '../util/constants'
 import { getPrice } from '../pricing/token'
 import { updatePricing } from '../pricing/geyser'
@@ -28,9 +28,7 @@ export function handleStaked(event: Staked): void {
   let user = User.load(event.params.user.toHexString());
 
   if (user === null) {
-    user = new User(event.params.user.toHexString());
-    user.operations = ZERO_BIG_INT;
-    user.earned = ZERO_BIG_DECIMAL;
+    user = initializeUser(event.params.user);
   }
 
   // load or create position

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -1,9 +1,20 @@
 // common utilities and helper functions
 
-import { BigDecimal, BigInt, log } from '@graphprotocol/graph-ts';
+import { Address, BigDecimal, BigInt, log } from '@graphprotocol/graph-ts';
+
+import { User } from '../../generated/schema'
+import { ZERO_BIG_INT, ZERO_BIG_DECIMAL } from '../util/constants'
 
 
 export function integerToDecimal(value: BigInt, decimals: BigInt = BigInt.fromI32(18)): BigDecimal {
   let denom = BigInt.fromI32(10).pow(decimals.toI32() as u8);
   return value.toBigDecimal().div(denom.toBigDecimal());
+}
+
+export function initializeUser(address: Address): User {
+  let user = new User(address.toHexString());
+  user.operations = ZERO_BIG_INT;
+  user.earned = ZERO_BIG_DECIMAL;
+
+  return user;
 }

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -11,7 +11,7 @@ export function integerToDecimal(value: BigInt, decimals: BigInt = BigInt.fromI3
   return value.toBigDecimal().div(denom.toBigDecimal());
 }
 
-export function initializeUser(address: Address): User {
+export function createNewUser(address: Address): User {
   let user = new User(address.toHexString());
   user.operations = ZERO_BIG_INT;
   user.earned = ZERO_BIG_DECIMAL;

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -91,6 +91,8 @@ templates:
           handler: handleRewardsFunded
         - event: RewardsDistributed(indexed address,uint256)
           handler: handleRewardsDistributed
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleOwnershipTransferred
         - event: RewardsUnlocked(uint256,uint256)
           handler: handleRewardsUnlocked
         - event: RewardsExpired(uint256,uint256,uint256)


### PR DESCRIPTION
## Changes
- Add `owner` field to Geyser entity that denotes the User that created that Geyser
- Add `geysers` field to User entity (derived from owner field) to list all geysers owned by that user

The main use for this is to be able to list a user's Geysers on their distribute/manage page.

## Testing
Tested on local Graph node

