### PR TITLE
Funding entity and geyser shares per second

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -70,7 +70,8 @@ type Geyser @entity {
   rewardsUSD: BigDecimal!
   tvl: BigDecimal!
   apy: BigDecimal!
-  sharesPerToken: BigDecimal!
+  stakingSharesPerToken: BigDecimal!
+  rewardSharesPerToken: BigDecimal!
   updated: BigInt!
 }
 
@@ -166,6 +167,7 @@ type Funding @entity {
   start: BigInt!
   end: BigInt!
 
-  sharesPerSecond: BigDecimal!
+  originalAmount: BigDecimal!
   shares: BigDecimal!
-}
+  sharesPerSecond: BigDecimal!
+  }

--- a/schema.graphql
+++ b/schema.graphql
@@ -59,6 +59,8 @@ type Geyser @entity {
   funded: BigDecimal!
   distributed: BigDecimal!
   gysrSpent: BigDecimal!
+  sharesPerSecond: BigDecimal!
+  fundings: [Funding!]!
 
   start: BigInt!
   end: BigInt!
@@ -151,4 +153,18 @@ type Transaction @entity {
   amount: BigDecimal!
   earnings: BigDecimal
   gysrSpent: BigDecimal
+}
+
+type Funding @entity {
+  # geyser id, created at timestamp
+  id: ID!
+
+  geyser: Geyser!
+
+  createdTimestamp: BigInt!
+  start: BigInt!
+  end: BigInt!
+
+  sharesPerSecond: BigDecimal!
+  amount: BigDecimal!
 }

--- a/schema.graphql
+++ b/schema.graphql
@@ -160,11 +160,12 @@ type Funding @entity {
   id: ID!
 
   geyser: Geyser!
+  token: Token!
 
   createdTimestamp: BigInt!
   start: BigInt!
   end: BigInt!
 
   sharesPerSecond: BigDecimal!
-  amount: BigDecimal!
+  shares: BigDecimal!
 }

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -7,7 +7,7 @@ import { ERC20 } from '../../generated/GeyserFactory/ERC20'
 import { Geyser, Token, User } from '../../generated/schema'
 import { Geyser as GeyserTemplate } from '../../generated/templates'
 import { integerToDecimal, createNewUser } from '../util/common'
-import { ZERO_BIG_INT, ZERO_BIG_DECIMAL } from '../util/constants'
+import { ZERO_BIG_INT, ZERO_BIG_DECIMAL, INITIAL_SHARES_PER_TOKEN } from '../util/constants'
 import { createNewToken } from '../pricing/token'
 
 
@@ -72,7 +72,8 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   geyser.rewardsUSD = ZERO_BIG_DECIMAL;
   geyser.tvl = ZERO_BIG_DECIMAL;
   geyser.apy = ZERO_BIG_DECIMAL;
-  geyser.sharesPerToken = BigDecimal.fromString('1000000');
+  geyser.stakingSharesPerToken = INITIAL_SHARES_PER_TOKEN;
+  geyser.rewardSharesPerToken = INITIAL_SHARES_PER_TOKEN;
   geyser.updated = ZERO_BIG_INT;
 
   geyser.save();

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -62,6 +62,8 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   geyser.funded = ZERO_BIG_DECIMAL;
   geyser.distributed = ZERO_BIG_DECIMAL;
   geyser.gysrSpent = ZERO_BIG_DECIMAL;
+  geyser.sharesPerSecond = ZERO_BIG_DECIMAL;
+  geyser.fundings = [];
 
   geyser.start = ZERO_BIG_INT;
   geyser.end = ZERO_BIG_INT;

--- a/src/mappings/geyser.ts
+++ b/src/mappings/geyser.ts
@@ -226,7 +226,8 @@ export function handleRewardsFunded(event: RewardsFunded): void {
   funding.start = event.params.start;
   funding.end = event.params.start.plus(event.params.duration);
   let formattedAmount = integerToDecimal(event.params.amount, rewardToken.decimals);
-  let shares = formattedAmount.times(geyser.sharesPerToken);
+  let shares = formattedAmount.times(geyser.rewardSharesPerToken);
+  funding.originalAmount = formattedAmount;
   funding.shares = shares;
   funding.sharesPerSecond = shares.div(event.params.duration.toBigDecimal());
 
@@ -302,7 +303,7 @@ export function handleRewardsExpired(event: RewardsExpired): void {
     // remove expired funding
     if (funding.start.equals(event.params.start)
     && funding.end.equals(funding.start.plus(event.params.duration))
-    && funding.shares.div(geyser.sharesPerToken).equals(amount)) {
+    && funding.originalAmount.equals(amount)) {
       store.remove('Funding', fundingId);
       break;
     }

--- a/src/pricing/geyser.ts
+++ b/src/pricing/geyser.ts
@@ -55,6 +55,8 @@ export function updatePricing(
     }
   }
 
+  geyser.sharesPerSecond = rate;
+
   // apy
   if (rate.gt(ZERO_BIG_DECIMAL)
     && rewardToken.price.gt(ZERO_BIG_DECIMAL)

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -34,4 +34,7 @@ export let HIGH_VOLUME_TOKENS: string[] = [
 export let USDT_WETH_PAIR = '0x0d4a11d5eeaac28ec3f61d100daf4d40471f1852';
 export let UNISWAP_FACTORY = '0x5c69bee701ef814a2b6a3edd4b1652cb9cc5aa6f';
 export let MIN_ETH_PRICING = BigDecimal.fromString('1.0');
-export let MIN_USD_PRICING = BigDecimal.fromString('1000.0')
+export let MIN_USD_PRICING = BigDecimal.fromString('1000.0');
+
+// contract
+export let INITIAL_SHARES_PER_TOKEN = BigDecimal.fromString('1000000');


### PR DESCRIPTION
- Create entity for funding on RewardsFunded and remove it on RewardsExpired
- Add sharesPerSecond to Geyser entity for more accurate client side calculations like estimated daily rewards and unlocked tokens