### PR TITLE
Track volume of each pool

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -73,6 +73,7 @@ type Geyser @entity {
   stakingSharesPerToken: BigDecimal!
   rewardSharesPerToken: BigDecimal!
   updated: BigInt!
+  volume: BigDecimal!
 }
 
 type _Schema_

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -42,7 +42,8 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   let user = User.load(event.params.user.toHexString());
 
   if (user == null) {
-    user = createNewUser(event.params.user, platform!);
+    user = createNewUser(event.params.user);
+    platform.users = platform.users.plus(BigInt.fromI32(1));
   }
 
   // geyser entity

--- a/src/mappings/factory.ts
+++ b/src/mappings/factory.ts
@@ -6,7 +6,7 @@ import { Geyser as GeyserContract } from '../../generated/GeyserFactory/Geyser'
 import { ERC20 } from '../../generated/GeyserFactory/ERC20'
 import { Geyser, Platform, Token, User } from '../../generated/schema'
 import { Geyser as GeyserTemplate } from '../../generated/templates'
-import { integerToDecimal, createNewUser } from '../util/common'
+import { integerToDecimal, createNewUser, createNewPlatform } from '../util/common'
 import { ZERO_BIG_INT, ZERO_BIG_DECIMAL, INITIAL_SHARES_PER_TOKEN, ZERO_ADDRESS } from '../util/constants'
 import { createNewToken } from '../pricing/token'
 
@@ -32,10 +32,17 @@ export function handleGeyserCreated(event: GeyserCreated): void {
     rewardToken.save();
   }
 
+  // platform
+  let platform = Platform.load(ZERO_ADDRESS);
+
+  if (platform === null) {
+    platform = createNewPlatform();
+  }
+
   let user = User.load(event.params.user.toHexString());
 
   if (user == null) {
-    user = createNewUser(event.params.user);
+    user = createNewUser(event.params.user, platform!);
   }
 
   // geyser entity
@@ -75,8 +82,8 @@ export function handleGeyserCreated(event: GeyserCreated): void {
   geyser.stakingSharesPerToken = INITIAL_SHARES_PER_TOKEN;
   geyser.rewardSharesPerToken = INITIAL_SHARES_PER_TOKEN;
   geyser.updated = ZERO_BIG_INT;
+  geyser.volume = ZERO_BIG_DECIMAL;
 
-  let platform = Platform.load(ZERO_ADDRESS);
   platform.pools = platform.pools.plus(BigInt.fromI32(1));
 
   geyser.save();

--- a/src/mappings/geyser.ts
+++ b/src/mappings/geyser.ts
@@ -30,7 +30,8 @@ export function handleStaked(event: Staked): void {
   let user = User.load(event.params.user.toHexString());
 
   if (user === null) {
-    user = createNewUser(event.params.user, platform!);
+    user = createNewUser(event.params.user);
+    platform.users = platform.users.plus(BigInt.fromI32(1));
   }
 
   // load or create position
@@ -296,7 +297,8 @@ export function handleOwnershipTransferred(event: OwnershipTransferred): void {
   }
 
   if (newOwner == null) {
-    newOwner = createNewUser(event.params.newOwner, platform!);
+    newOwner = createNewUser(event.params.newOwner);
+    platform.users = platform.users.plus(BigInt.fromI32(1));
     newOwner.save()
   }
 

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -11,11 +11,10 @@ export function integerToDecimal(value: BigInt, decimals: BigInt = BigInt.fromI3
   return value.toBigDecimal().div(denom.toBigDecimal());
 }
 
-export function createNewUser(address: Address, platform: Platform): User {
+export function createNewUser(address: Address): User {
   let user = new User(address.toHexString());
   user.operations = ZERO_BIG_INT;
   user.earned = ZERO_BIG_DECIMAL;
-  platform.users = platform.users.plus(BigInt.fromI32(1));
 
   return user;
 }

--- a/src/util/common.ts
+++ b/src/util/common.ts
@@ -11,17 +11,11 @@ export function integerToDecimal(value: BigInt, decimals: BigInt = BigInt.fromI3
   return value.toBigDecimal().div(denom.toBigDecimal());
 }
 
-export function createNewUser(address: Address): User {
+export function createNewUser(address: Address, platform: Platform): User {
   let user = new User(address.toHexString());
-  let platform = Platform.load(ZERO_ADDRESS);
-  if (platform === null) {
-    platform = createNewPlatform();
-  }
   user.operations = ZERO_BIG_INT;
   user.earned = ZERO_BIG_DECIMAL;
   platform.users = platform.users.plus(BigInt.fromI32(1));
-
-  platform.save();
 
   return user;
 }


### PR DESCRIPTION
- Track volume on individual pools. We can use this to calculate a rough 24h volume by leveraging the `block` parameter on queries
- Users was not getting calculated correctly so I pulled platform create into a top level handler and it seems to have fixed it