### PR TITLE
Make all fields on transactions required

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -167,8 +167,8 @@ type Transaction @entity {
   user: User!
 
   amount: BigDecimal!
-  earnings: BigDecimal
-  gysrSpent: BigDecimal
+  earnings: BigDecimal!
+  gysrSpent: BigDecimal!
 }
 
 type Funding @entity {

--- a/src/mappings/geyserv1.ts
+++ b/src/mappings/geyserv1.ts
@@ -81,6 +81,8 @@ export function handleStaked(event: Staked): void {
   transaction.pool = pool.id;
   transaction.user = user.id;
   transaction.amount = integerToDecimal(event.params.amount, stakingToken.decimals);
+  transaction.earnings = ZERO_BIG_DECIMAL;
+  transaction.gysrSpent = ZERO_BIG_DECIMAL;
 
   // update pricing info
   updateGeyserV1(pool, platform, contract, stakingToken, rewardToken, event.block.timestamp);

--- a/src/mappings/stakingmodule.ts
+++ b/src/mappings/stakingmodule.ts
@@ -70,6 +70,8 @@ export function handleStaked(event: Staked): void {
   transaction.pool = pool.id;
   transaction.user = user.id;
   transaction.amount = integerToDecimal(event.params.amount, stakingToken.decimals);
+  transaction.earnings = ZERO_BIG_DECIMAL;
+  transaction.gysrSpent = ZERO_BIG_DECIMAL;
 
   // update pricing info
   updatePool(pool, platform, stakingToken, rewardToken, event.block.timestamp);


### PR DESCRIPTION
It turns out having these fields as optional is unideal for sorting because the null value gets ranked above everything else when sorting in descending order, so it’s better to mark these as 0 as the default.

Additionally, when people didn’t spend GYSR when staking in a fountain the `gysrSpent` field is null, instead of 0.