### PR TITLE
Funding schedules fix

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -185,6 +185,8 @@ type Funding @entity {
   originalAmount: BigDecimal!
   shares: BigDecimal!
   sharesPerSecond: BigDecimal!
+
+  cleaned: Boolean!
 }
 
 type PoolDayData @entity {

--- a/src/mappings/geyserv1.ts
+++ b/src/mappings/geyserv1.ts
@@ -232,6 +232,7 @@ export function handleRewardsFunded(event: RewardsFunded): void {
   funding.originalAmount = formattedAmount;
   funding.shares = shares;
   funding.sharesPerSecond = shares.div(event.params.duration.toBigDecimal());
+  funding.cleaned = false;
   funding.save();  // save before pricing
 
   pool.fundings = pool.fundings.concat([funding.id])
@@ -313,11 +314,12 @@ export function handleRewardsExpired(event: RewardsExpired): void {
     let fundingId = (pool.fundings as string[])[i];
     let funding = Funding.load(fundingId);
 
-    // remove expired funding
+    // mark expired funding as cleaned
     if (funding.start.equals(event.params.start)
       && funding.end.equals(funding.start.plus(event.params.duration))
       && funding.originalAmount.equals(amount)) {
-      store.remove('Funding', fundingId);
+      funding.cleaned = true;
+      funding.save();
       break;
     }
   }

--- a/src/mappings/geyserv1.ts
+++ b/src/mappings/geyserv1.ts
@@ -310,9 +310,9 @@ export function handleRewardsExpired(event: RewardsExpired): void {
   let rewardToken = Token.load(pool.rewardToken);
   let amount = integerToDecimal(event.params.amount, rewardToken.decimals);
 
-  for (let i = 0; i < pool.fundings.length; i++) {
-    let fundingId = (pool.fundings as string[])[i];
-    let funding = Funding.load(fundingId);
+  let fundings = pool.fundings;
+  for (let i = 0; i < fundings.length; i++) {
+    let funding = Funding.load(fundings[i]);
 
     // mark expired funding as cleaned
     if (funding.start.equals(event.params.start)

--- a/src/mappings/rewardmodule.ts
+++ b/src/mappings/rewardmodule.ts
@@ -151,9 +151,9 @@ export function handleRewardsExpired(event: RewardsExpired): void {
   let rewardToken = Token.load(pool.rewardToken);
   let amount = integerToDecimal(event.params.amount, rewardToken.decimals);
 
-  for (let i = 0; i < pool.fundings.length; i++) {
-    let fundingId = (pool.fundings as string[])[i];
-    let funding = Funding.load(fundingId);
+  let fundings = pool.fundings;
+  for (let i = 0; i < fundings.length; i++) {
+    let funding = Funding.load(fundings[i]);
 
     // mark expired funding as cleaned
     if (funding.start.equals(event.params.timestamp)

--- a/src/mappings/rewardmodule.ts
+++ b/src/mappings/rewardmodule.ts
@@ -49,11 +49,9 @@ export function handleRewardsFunded(event: RewardsFunded): void {
   funding.createdTimestamp = event.block.timestamp;
   funding.start = event.params.timestamp;
   funding.end = end;
-  let formattedAmount = integerToDecimal(event.params.amount, rewardToken.decimals);
-  let shares = formattedAmount.times(pool.rewardSharesPerToken);
-  funding.originalAmount = formattedAmount;
-  funding.shares = shares;
-  funding.sharesPerSecond = shares.div(duration.toBigDecimal());
+  funding.originalAmount = integerToDecimal(event.params.amount, rewardToken.decimals);
+  funding.shares = integerToDecimal(event.params.shares, rewardToken.decimals);
+  funding.sharesPerSecond = funding.shares.div(duration.toBigDecimal());
   funding.save(); // save before pricing
 
   pool.fundings = pool.fundings.concat([funding.id])

--- a/src/util/pool.ts
+++ b/src/util/pool.ts
@@ -38,7 +38,7 @@ export function updatePool(
     : INITIAL_SHARES_PER_TOKEN;
   let rewardSharesPerToken = pool.rewards.gt(ZERO_BIG_DECIMAL)
     ? integerToDecimal(
-      rewardContract.totalShares(Address.fromString(rewardToken.id)),
+      rewardContract.lockedShares(Address.fromString(rewardToken.id)),
       rewardToken.decimals
     ).div(pool.rewards)
     : INITIAL_SHARES_PER_TOKEN;

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -210,6 +210,8 @@ templates:
           handler: handleRewardsFunded
         - event: RewardsDistributed(indexed address,indexed address,uint256,uint256)
           handler: handleRewardsDistributed
+        - event: RewardsExpired(indexed address,uint256,uint256,uint256)
+          handler: handleRewardsExpired
         - event: GysrSpent(indexed address,uint256)
           handler: handleGysrSpent
       file: ./src/mappings/rewardmodule.ts


### PR DESCRIPTION
### Overview
This PR contains a few minor fixes and updates for funding schedules

### Changes
- fix rewards shares per token calculation
- pull shares directly from event in v2 funding
- mark expired funding as `cleaned` rather than removing entity
- fix iteration over funding schedules in expiration handler