### PR TITLE
Balancer LP token pricing bug fix

### DIFF
--- a/src/pricing/balancer.ts
+++ b/src/pricing/balancer.ts
@@ -63,7 +63,7 @@ export function getBalancerLiquidityTokenPrice(address: Address): BigDecimal {
       if (tokenPrice == ZERO_BIG_DECIMAL) {
         continue;
       }
-      let tokenContract = ERC20.bind(address);
+      let tokenContract = ERC20.bind(tokenAddresses[i]);
       let tokenAmount = integerToDecimal(tokenBalances[i], BigInt.fromI32(tokenContract.decimals()));
       let tokenWeight = integerToDecimal(weights[i]);
       return getPriceFromWeight(tokenAmount, tokenWeight, tokenPrice, totalSupply)


### PR DESCRIPTION
I was using the address of the LP token that was being priced, rather than the address of the token in the pool that was being used to determine TVL