### PR TITLE
Improve support for multiple Uniswap factories

### DIFF
--- a/src/util/constants.template.ts
+++ b/src/util/constants.template.ts
@@ -36,7 +36,6 @@ export let HIGH_VOLUME_TOKENS: string[] = [
 export let USDT_WETH_PAIR = '{{usdt_weth_address}}';
 export let UNISWAP_FACTORY = '{{uniswap_factory}}';
 export let SUSHI_FACTORY = '{{sushi_factory}}';
-export let MIN_ETH_PRICING = BigDecimal.fromString('5.0');
 export let MIN_USD_PRICING = BigDecimal.fromString('10000.0');
 
 // contract


### PR DESCRIPTION
## Overview
This addresses a pricing edge case where the stablecoin pairing exists on both uniswap and sushi, the uniswap pool is below the liquidity threshold, and the sushi liquidity is above the liquidity threshold.

## Changes
- iterate over each factory and STABLE-TKN combination explicitly
- handle edge case described above by doing full liquidity check on each candidate
- support for 3+ uniswap factories (including clones) on a single chain if desired

## Testing
This commit has been deployed and indexed (v2 only) in a development subgraph here
https://thegraph.com/legacy-explorer/subgraph/devinaconley/gysr-dev

You can verify that results and pricing are as expected for both uniswap and sushiswap tokens