### PR TITLE
Multi rewards shares info

### DIFF
--- a/src/modules/erc20multi.ts
+++ b/src/modules/erc20multi.ts
@@ -1,0 +1,46 @@
+// handler methods for the erc20 multi reward module
+
+import { Address, BigInt, Bytes, log, store } from '@graphprotocol/graph-ts';
+import { ERC20BaseRewardModule as ERC20BaseRewardModuleContract } from '../../generated/templates/RewardModule/ERC20BaseRewardModule';
+import { ERC20MultiRewardModule as ERC20MultiRewardModuleContract } from '../../generated/templates/RewardModule/ERC20MultiRewardModule';
+import {
+  Staked1 as Staked,
+  Unstaked1 as Unstaked,
+  Claimed1 as Claimed
+} from '../../generated/templates/StakingModule/Events';
+import { RewardsFunded } from '../../generated/templates/RewardModule/Events';
+import {
+  Pool,
+  Token,
+  Funding,
+  Position,
+  User,
+  Stake,
+  PoolRewardToken
+} from '../../generated/schema';
+import { integerToDecimal } from '../util/common';
+import { ZERO_BIG_INT, ZERO_BIG_DECIMAL, INITIAL_SHARES_PER_TOKEN } from '../util/constants';
+
+export function updatePoolMulti(
+  pool: Pool,
+  tokens: Map<String, Token>,
+  rewardTokens: Map<String, PoolRewardToken>,
+  timestamp: BigInt
+): void {
+  let contract = ERC20BaseRewardModuleContract.bind(Address.fromString(pool.rewardModule));
+
+  for (let i = 0; i < rewardTokens.keys().length; i++) {
+    let tkn = rewardTokens.keys()[i];
+
+    let rewardSharesPerToken = INITIAL_SHARES_PER_TOKEN;
+    if (rewardTokens[tkn].amount.gt(ZERO_BIG_DECIMAL)) {
+      rewardSharesPerToken = integerToDecimal(
+        contract.lockedShares(Address.fromString(tkn)),
+        tokens[tkn].decimals
+      ).div(rewardTokens[tkn].amount);
+    }
+
+    rewardTokens[tkn].sharesPerToken = rewardSharesPerToken;
+    if (i == 0) pool.rewardSharesPerToken = rewardSharesPerToken;
+  }
+}

--- a/src/pricing/pool.ts
+++ b/src/pricing/pool.ts
@@ -104,7 +104,12 @@ export function updatePricing(
       );
     }
   }
-  pool.sharesPerSecond = rate;
+
+  // set pool shares per second to first reward token (backward compat)
+  if (fundings.length) {
+    let tkn = rewardTokens.keys()[0];
+    pool.sharesPerSecond = rewardTokens[tkn].sharesPerSecond;
+  }
 
   // apr
   if (rate.gt(ZERO_BIG_DECIMAL) && pool.stakedUSD.gt(ZERO_BIG_DECIMAL)) {

--- a/src/util/pool.ts
+++ b/src/util/pool.ts
@@ -18,6 +18,7 @@ import { updatePricing } from '../pricing/pool';
 import { BASE_REWARD_MODULE_TYPES } from './constants';
 import { updatePoolCompetitive } from '../modules/erc20competitive';
 import { updatePoolLinear } from '../modules/erc20linear';
+import { updatePoolMulti } from '../modules/erc20multi';
 
 export function updatePool(
   pool: Pool,
@@ -74,7 +75,9 @@ export function updatePool(
   }
 
   // module specific pool updates
-  if (BASE_REWARD_MODULE_TYPES.includes(pool.rewardModuleType)) {
+  if (pool.rewardModuleType == 'ERC20Multi') {
+    updatePoolMulti(pool, tokens, rewardTokens, timestamp);
+  } else if (BASE_REWARD_MODULE_TYPES.includes(pool.rewardModuleType)) {
     updatePoolCompetitive(pool, tokens, rewardTokens, timestamp);
   } else if (pool.rewardModuleType == 'ERC20Linear') {
     updatePoolLinear(pool, tokens, rewardTokens, timestamp);


### PR DESCRIPTION
- set `pool.sharesPerSecond` to first reward `token.sharesPerSecond` (backwards compatibility)
- update shares per token for all reward tokens

deployed here
https://thegraph.com/hosted-service/subgraph/gysr-io/gysr-goerli-staging

and a good example query
```graphql
{
  pools(first: 5, orderDirection:desc, orderBy:createdTimestamp) {
    id
    name
    stakingToken {
      id
    }
    rewardToken {
      id
    }
    sharesPerSecond
    rewardSharesPerToken
    rewardTokens{
      sharesPerToken
      sharesPerSecond
      amount
    }
  }
}
```
